### PR TITLE
Update project name to den in sign-certificate command

### DIFF
--- a/commands/sign-certificate.cmd
+++ b/commands/sign-certificate.cmd
@@ -51,7 +51,7 @@ openssl x509 -req -days 365 -sha256 -extensions v3_req            \
   -in "${WARDEN_SSL_DIR}/certs/${CERTIFICATE_NAME}.csr.pem"       \
   -out "${WARDEN_SSL_DIR}/certs/${CERTIFICATE_NAME}.crt.pem" 
 
-if [[ "$(cd "${WARDEN_HOME_DIR}" && docker-compose -p warden -f "${WARDEN_DIR}/docker/docker-compose.yml" ps -q traefik)" ]]
+if [[ "$(cd "${WARDEN_HOME_DIR}" && docker-compose -p den -f "${WARDEN_DIR}/docker/docker-compose.yml" ps -q traefik)" ]]
 then
   echo "==> Updating traefik"
   "${WARDEN_DIR}/bin/den" svc up traefik


### PR DESCRIPTION
Refs swiftotter/den#26

This fixes an invalid reference to a docker-compose project name, which causes Traefik to not be reloaded with the new certificate automatically.