### PR TITLE
Generate certificates for domains were in Warden

### DIFF
--- a/commands/install.cmd
+++ b/commands/install.cmd
@@ -55,7 +55,7 @@ fi
 if [[ -d ~/.warden/ssl/certs/ ]]; then
   domains_to_generate="$(diff -B <(ls ~/.den/ssl/certs/ | grep .key.pem | sed 's/.key.pem//' | grep -v warden.test)  <(ls ~/.warden/ssl/certs/ | grep .key.pem | sed 's/.key.pem//' | grep -v warden.test) | grep '^>' | sed 's/^>\ //')"
   if [[ -n "$domains_to_generate" ]]; then
-    echo Generating certificates that were there in Warden...
+    echo "Generating certificates present in Warden..."
 
     echo "$domains_to_generate" | while read i; do
       den sign-certificate "$i"


### PR DESCRIPTION
Fixes https://github.com/swiftotter/den/issues/34

So the algorigthm is following:
1. Check if we have ~/.warden/ssl/certs/ folder
2. Retrieve list of certificate domains listed in `~/.warden/ssl/certs` and in `~/.den/ssl/certs`, compare them, and find the only missing in the Den SSL folder
3. Run `den sign-certificate` for all listed certificates