### PR TITLE
Add compatibility with warden for project-level commands

### DIFF
--- a/bin/den
+++ b/bin/den
@@ -2,6 +2,8 @@
 set -e
 trap 'error "$(printf "Command \`%s\` at $BASH_SOURCE:$LINENO failed with exit code $?" "$BASH_COMMAND")"' ERR
 
+export readonly WARDEN_BIN=den
+
 ## find directory where this script is located following symlinks if neccessary
 readonly WARDEN_DIR="$(
   cd "$(

--- a/bin/den
+++ b/bin/den
@@ -5,7 +5,7 @@ trap 'error "$(printf "Command \`%s\` at $BASH_SOURCE:$LINENO failed with exit c
 # add compatibility with warden commands by adding WARDEN_BIN viriable and warden function
 export readonly WARDEN_BIN=den
 function warden() {
-  den $@
+  den "$@"
 }
 export -f warden
 

--- a/bin/den
+++ b/bin/den
@@ -2,7 +2,12 @@
 set -e
 trap 'error "$(printf "Command \`%s\` at $BASH_SOURCE:$LINENO failed with exit code $?" "$BASH_COMMAND")"' ERR
 
+# add compatibility with warden commands by adding WARDEN_BIN viriable and warden function
 export readonly WARDEN_BIN=den
+function warden() {
+  den $@
+}
+export -f warden
 
 ## find directory where this script is located following symlinks if neccessary
 readonly WARDEN_DIR="$(


### PR DESCRIPTION
### Issue
Warden allows us to create new project-level commands in `.warden/commmands` folder.
Sometimes these commands use `warden ...` commands, which aren't available in Den, so these commands are failing.

### Solution
To fix that issue, I suggest 
1. creating a new variable, `WARDEN_BIN` that will be set to `den`. So that these custom commands could use `WARDEN_BIN=${WARDEN_BIN:-warden}` to understand what command should be executed.
2. create a function named `warden` that will forward all arguments to `den` command, so that we don't need to change the commands

### Example script
```
#!/usr/bin/env bash
[[ ! ${WARDEN_DIR} ]] && >&2 echo -e "\033[31mThis script is not intended to be run directly!\033[0m" && exit 1

set -euo pipefail

echo "Real binary is ${WARDEN_BIN:-warden}"

warden sign-certificate mydomain.test

# we can also use
# ${WARDEN_BIN:-warden} sign-certificate mydomain.test
```