### PR TITLE
[INFRA] #55: add exif support and sylius image type for php-fpm

### DIFF
--- a/images/php-fpm/sylius/Dockerfile
+++ b/images/php-fpm/sylius/Dockerfile
@@ -1,0 +1,8 @@
+ARG ENV_SOURCE_IMAGE
+ARG PHP_VERSION
+FROM ${ENV_SOURCE_IMAGE}:${PHP_VERSION}
+USER root
+
+RUN install-php-extensions exif
+
+USER www-data


### PR DESCRIPTION
This PR is variant A, adding a new image type for sylius adding exif only for this image type. Close [Variant B](https://github.com/swiftotter/den/pull/57) if you use this approach