### PR TITLE
[INFRA] #55: add exif support for base php-fpm

### DIFF
--- a/images/php-fpm/Dockerfile
+++ b/images/php-fpm/Dockerfile
@@ -19,6 +19,7 @@ COPY --from=mhs-builder /go/bin/mhsendmail /usr/local/bin/mhsendmail
 RUN chmod +x /usr/local/bin/install-php-extensions && install-php-extensions \
     amqp \
     bcmath \
+    exif \
     gd \
     intl \
     imagick \


### PR DESCRIPTION
This PR is variant B, adding exif to the base php-fpm image. Close [Variant A](https://github.com/swiftotter/den/pull/56) if you use this approach