### PR TITLE
Fix mutagen config file

### DIFF
--- a/environments/magento2/magento2.mutagen.yml
+++ b/environments/magento2/magento2.mutagen.yml
@@ -8,7 +8,7 @@ sync:
       vcs: false
       paths:
         # Root .git folder 
-         - "/.git/"
+        - "/.git/"
 
         # System files
         - ".DS_Store"


### PR DESCRIPTION
Fixes the issue with warden env up:
```
Error: unable to load configuration file: unable to unmarshal data: yaml: line 13: did not find expected key
ERROR: Command `mutagen sync create -c "${MUTAGEN_SYNC_FILE}" --label "warden-sync=${WARDEN_ENV_NAME}" --ignore "${WARDEN_SYNC_IGNORE:-}" "${WARDEN_ENV_PATH}${WARDEN_WEB_ROOT:-}" "docker://$(den env ps -q php-fpm)/var/www/html"` at /opt/homebrew/Cellar/den/1.0.0-beta.4/commands/sync.cmd:45 failed with exit code 1
```