### PR TITLE
Make global portainer service optional

### DIFF
--- a/commands/install.cmd
+++ b/commands/install.cmd
@@ -97,3 +97,11 @@ fi
 
 ## append settings for tunnel.den.test in /etc/ssh/ssh_config
 installSshConfig
+
+## Add optional Den configuration file
+if [[ ! -f "${WARDEN_HOME_DIR}/.env" ]]; then
+	cat >> "${WARDEN_HOME_DIR}/.env" <<-EOT
+		# Set to "1" to enable global Portainer service
+		DEN_SERVICE_PORTAINER=0
+	EOT
+fi

--- a/commands/svc.cmd
+++ b/commands/svc.cmd
@@ -18,6 +18,18 @@ DOCKER_COMPOSE_ARGS=()
 DOCKER_COMPOSE_ARGS+=("-f")
 DOCKER_COMPOSE_ARGS+=("${WARDEN_DIR}/docker/docker-compose.yml")
 
+# Load optional service flags
+if [[ -f "${WARDEN_HOME_DIR}/.env" ]]; then
+    # Portainer service
+    eval "$(grep "^DEN_SERVICE_PORTAINER" "${WARDEN_HOME_DIR}/.env")"
+fi
+
+DEN_SERVICE_PORTAINER="${DEN_SERVICE_PORTAINER:-0}"
+if [[ "${DEN_SERVICE_PORTAINER}" == 1 ]]; then
+    DOCKER_COMPOSE_ARGS+=("-f")
+    DOCKER_COMPOSE_ARGS+=("${WARDEN_DIR}/docker/portainer-service.yml")
+fi
+
 ## special handling when 'svc up' is run
 if [[ "${WARDEN_PARAMS[0]}" == "up" ]]; then
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -27,19 +27,6 @@ services:
       - traefik.http.routers.traefik.service=api@internal
     restart: ${WARDEN_RESTART_POLICY:-always}
 
-  portainer:
-    container_name: portainer
-    image: portainer/portainer-ce
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-      - portainer:/data
-    labels:
-      - traefik.enable=true
-      - traefik.http.routers.portainer.tls=true
-      - traefik.http.routers.portainer.rule=Host(`portainer.${WARDEN_SERVICE_DOMAIN:-den.test}`)||Host(`portainer.warden.test`)
-      - traefik.http.services.portainer.loadbalancer.server.port=9000
-    restart: ${WARDEN_RESTART_POLICY:-always}
-
   dnsmasq:
     container_name: dnsmasq
     image: ghcr.io/swiftotter/den-dnsmasq

--- a/docker/portainer-service.yml
+++ b/docker/portainer-service.yml
@@ -1,0 +1,14 @@
+version: "3.5"
+services:
+  portainer:
+    container_name: portainer
+    image: portainer/portainer-ce
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - portainer:/data
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.portainer.tls=true
+      - traefik.http.routers.portainer.rule=Host(`portainer.${WARDEN_SERVICE_DOMAIN:-den.test}`)||Host(`portainer.warden.test`)
+      - traefik.http.services.portainer.loadbalancer.server.port=9000
+    restart: ${WARDEN_RESTART_POLICY:-always}


### PR DESCRIPTION
- Creates `${WARDEN_HOME_DIR}/.env` entry during install to disable portainer service
- By default portainer is not started
- Editing `${WARDEN_HOME_DIR}/.env` and setting `DEN_SERVICE_PORTAINER=1` then portainer will start
- Moved portainer service to separate yaml file that is included as needed