### PR TITLE
swiftotter/den#87: Fix uninitalized variable error

### DIFF
--- a/commands/sign-certificate.cmd
+++ b/commands/sign-certificate.cmd
@@ -51,7 +51,7 @@ openssl x509 -req -days 365 -sha256 -extensions v3_req            \
   -in "${WARDEN_SSL_DIR}/certs/${CERTIFICATE_NAME}.csr.pem"       \
   -out "${WARDEN_SSL_DIR}/certs/${CERTIFICATE_NAME}.crt.pem" 
 
-if [[ "$(cd "${WARDEN_HOME_DIR}" && docker compose -p den -f "${WARDEN_DIR}/docker/docker-compose.yml" ps -q traefik)" ]]
+if [[ "$(den svc ps -q traefik)" ]]
 then
   echo "==> Updating traefik"
   "${WARDEN_DIR}/bin/den" svc up traefik


### PR DESCRIPTION
Removed the custom constructed `docker-compose` call with a simpler `den svc` call. This way any and all variables needed for the global services `docker-compose.yml` file are guaranteed to be defined.