### PR TITLE
Make version pull from build context

### DIFF
--- a/docker/dashboard/Dockerfile
+++ b/docker/dashboard/Dockerfile
@@ -1,4 +1,11 @@
+ARG DEN_VERSION="main (development)"
+
 FROM nginx:alpine
+ARG DEN_VERSION
+
+ENV DEN_VERSION=${DEN_VERSION}
 
 ADD index.html /usr/share/nginx/html/index.html
 ADD img/Dnsmasq_icon.svg /usr/share/nginx/html/img/Dnsmasq_icon.svg
+
+RUN sed -ie "s/{{DEN_VERSION}}/${DEN_VERSION}/g" /usr/share/nginx/html/index.html

--- a/docker/dashboard/index.html
+++ b/docker/dashboard/index.html
@@ -83,7 +83,7 @@
 </div><br>
     by Swiftotter<br>
     fork of Warden by David Alger<br>
-    v.in-dev<br>
+    v.{{DEN_VERSION}}<br>
     <a href="https://github.com/swiftotter/den/releases">Check for Updates</a>
 </header>
 <ul class="services-list">


### PR DESCRIPTION
This updates the dockerfile for the dashboard to allow specifying a version, and putting that version into the index.html file.

This has a counterpart PR in swiftotter/homebrew-den which enables this to work.