### PR TITLE
Add support for `ps` (with `--pid` option) required by Magento Integration Tests

### DIFF
--- a/images/php-fpm/Dockerfile
+++ b/images/php-fpm/Dockerfile
@@ -44,7 +44,7 @@ COPY --from=composer:1 /usr/bin/composer /usr/bin/composer1
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer2
 
 # Install helpful utilities
-RUN apk --no-cache add jq bash patch pv nano vim mariadb-client sudo busybox-initscripts gettext ca-certificates shadow git rsync bash-completion
+RUN apk --no-cache add jq bash patch pv procps nano vim mariadb-client sudo busybox-initscripts gettext ca-certificates shadow git rsync bash-completion
 
 # Configure www-data user as primary php-fpm user for better local dev experience
 RUN groupmod -g 1000 www-data && usermod -u 1000 www-data \


### PR DESCRIPTION
When running Integration Tests, PHPUnit is unable to perform valid memory usage estimation.
This change adds `ps` command required by Magento Integration Tests Framework.

Before:
```
$ vendor/bin/phpunit -c$(pwd)/dev/tests/integration/phpunit.xml

Fatal error: Uncaught Exception: sh: tasklist.exe: not found in /var/www/html/vendor/magento/framework/Shell.php:65
Stack trace:
#0 /var/www/html/dev/tests/integration/framework/Magento/TestFramework/Helper/Memory.php(92): Magento\Framework\Shell->execute('tasklist.exe /fi 'PID eq 117' /fo CSV /nh 2>&1', Array)
#1 /var/www/html/dev/tests/integration/framework/Magento/TestFramework/Helper/Memory.php(58): Magento\TestFramework\Helper\Memory->_getWinProcessMemoryUsage(117)
#2 /var/www/html/dev/tests/integration/framework/Magento/TestFramework/MemoryLimit.php(127): Magento\TestFramework\Helper\Memory->getRealMemoryUsage()
#3 /var/www/html/dev/tests/integration/framework/Magento/TestFramework/MemoryLimit.php(59): Magento\TestFramework\MemoryLimit->_getUsage()
#4 /var/www/html/dev/tests/integration/framework/Magento/TestFramework/Bootstrap/Memory.php(50): Magento\TestFramework\MemoryLimit->printStats()
#5 [internal function]: Magento\TestFramework\Bootstrap\Memory->displayStats()
#6 {main}

Next Magento\Framework\Exception\LocalizedException: Command returned non-zero exit code:
`tasklist.exe /fi 'PID eq 117' /fo CSV /nh 2>&1` in /var/www/html/vendor/magento/framework/Shell.php:66
Stack trace:
#0 /var/www/html/dev/tests/integration/framework/Magento/TestFramework/Helper/Memory.php(92): Magento\Framework\Shell->execute('tasklist.exe /fi 'PID eq 117' /fo CSV /nh 2>&1', Array)
#1 /var/www/html/dev/tests/integration/framework/Magento/TestFramework/Helper/Memory.php(58): Magento\TestFramework\Helper\Memory->_getWinProcessMemoryUsage(117)
#2 /var/www/html/dev/tests/integration/framework/Magento/TestFramework/MemoryLimit.php(127): Magento\TestFramework\Helper\Memory->getRealMemoryUsage()
#3 /var/www/html/dev/tests/integration/framework/Magento/TestFramework/MemoryLimit.php(59): Magento\TestFramework\MemoryLimit->_getUsage()
#4 /var/www/html/dev/tests/integration/framework/Magento/TestFramework/Bootstrap/Memory.php(50): Magento\TestFramework\MemoryLimit->printStats()
#5 [internal function]: Magento\TestFramework\Bootstrap\Memory->displayStats()
#6 {main}
  thrown in /var/www/html/vendor/magento/framework/Shell.php on line 66
```

After
```
$ vendor/bin/phpunit -c$(pwd)/dev/tests/integration/phpunit.xml
PHPUnit 9.5.25 #StandWithUkraine

Warning:       Using a custom test suite loader is deprecated

No tests executed!

=== Memory Usage System Stats ===
Memory usage (OS):      109.19M (141.81% of 77.00M reported by PHP)
Estimated memory leak:  32.19M (29.48% of used memory)
```