### PR TITLE
Use latest magerun version

### DIFF
--- a/images/php-fpm/magento2/Dockerfile
+++ b/images/php-fpm/magento2/Dockerfile
@@ -3,7 +3,7 @@ ARG PHP_VERSION
 FROM ${ENV_SOURCE_IMAGE}:${PHP_VERSION}
 USER root
 
-ADD https://files.magerun.net/n98-magerun2.phar /usr/local/bin/n98-magerun2
+ADD https://files.magerun.net/n98-magerun2-latest.phar /usr/local/bin/n98-magerun2
 RUN chmod +rx /usr/local/bin/n98-magerun2 \
     && ln -s /usr/local/bin/n98-magerun2 /usr/local/bin/n98-magerun \
     && ln -s /usr/local/bin/n98-magerun2 /usr/local/bin/magerun2 \


### PR DESCRIPTION
This PR changes the URL so that the latest version of magerun will be downloaded. The current version present in the code is outdated and its listed under https://files.magerun.net/old_versions.php, which was last updated on 2022-05-23 12:05