### PR TITLE
Adding Fish and Zsh alternative shells

### DIFF
--- a/commands/shell.cmd
+++ b/commands/shell.cmd
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
 [[ ! ${WARDEN_DIR} ]] && >&2 echo -e "\033[31mThis script is not intended to be run directly!\033[0m" && exit 1
 
+# Load in the user-specific shell command
+if [[ -f "${WARDEN_HOME_DIR}/.env" ]]; then
+    eval "$(cat "${WARDEN_HOME_DIR}/.env" | sed 's/\r$//g' | grep "^WARDEN_ENV_SHELL_COMMAND")"
+fi
+
 WARDEN_ENV_PATH="$(locateEnvPath)" || exit $?
 loadEnvConfig "${WARDEN_ENV_PATH}" || exit $?
 
 ## set defaults for this command which can be overridden either using exports in the user
 ## profile or setting them in the .env configuration on a per-project basis
-WARDEN_ENV_SHELL_COMMAND=${WARDEN_ENV_SHELL_COMMAND:-bash}
+WARDEN_ENV_SHELL_COMMAND=${USE_SHELL:-${WARDEN_ENV_SHELL_COMMAND:-bash}}
 WARDEN_ENV_SHELL_CONTAINER=${WARDEN_ENV_SHELL_CONTAINER:-php-fpm}
 
 ## allow return codes from sub-process to bubble up normally

--- a/docs/configuration/alternative-shells.md
+++ b/docs/configuration/alternative-shells.md
@@ -1,0 +1,60 @@
+# Alternative Shells
+
+:::{warning}
+Currently the only images that support the alternative shells described here
+are those based off of the php-fpm image. This includes:
+
+ - den-php-fpm
+ - den-php-fpm-magento2
+ - den-php-debug
+:::
+
+Some Den containers now come with some alternative shells to BaSH. By default
+BaSH is the shell used when running `den shell`, and if no shell is specified
+Den will default to using BaSH.
+
+## Specifying an alternative shell
+
+You can specify the shell to use when running `den shell` in three different
+ways. As Den parses your command it will evaluate which shell to use based on
+the following order of preference:
+
+ 1. One-Time Specification
+ 2. Project Specific
+ 3. User Specific
+
+### User Specific
+
+Edit your `~/.den/.env` file to specify the setting of
+`WARDEN_ENV_SHELL_COMMAND` with your choice of shell from below:
+
+```
+WARDEN_ENV_SHELL_COMMAND=fish
+```
+
+### Project Specific
+
+Within your project environment, edit the `.env` file and specify the
+`WARDEN_ENV_SHELL_COMMAND` variable with your choise of shell from below:
+
+```
+WARDEN_ENV_SHELL_COMMAND=fish
+```
+
+### One-Time Specification
+
+Using an environment variable you can specify the shell to use on a
+per-execution basis (or for an single session) using the variable: `USE_SHELL`.
+
+```bash
+USE_SHELL=fish den shell
+```
+
+## Available Shells
+
+The following shells are currently available for use:
+
+ - ash
+ - bash
+ - fish
+ - zsh

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,6 +6,9 @@ Launch a shell session within the project environment's `php-fpm` container:
 
     den shell
 
+For use with alternative shells, see the
+[Alternative Shells](configuration/alternative-shells.md) page
+
 Stopping a running environment:
 
     den env stop

--- a/images/php-fpm/Dockerfile
+++ b/images/php-fpm/Dockerfile
@@ -44,7 +44,31 @@ COPY --from=composer:1 /usr/bin/composer /usr/bin/composer1
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer2
 
 # Install helpful utilities
-RUN apk --no-cache add jq bash patch pv procps nano vim mariadb-client sudo busybox-initscripts gettext ca-certificates shadow git rsync bash-completion
+RUN apk --no-cache add \
+    jq \
+    bash \
+    patch \
+    pv \
+    procps \
+    nano \
+    vim \
+    mariadb-client \
+    sudo \
+    busybox-initscripts \
+    gettext \
+    ca-certificates \
+    shadow \
+    git \
+    rsync \
+    bash-completion \
+    zsh \
+    composer-zsh-completion \
+    git-zsh-completion \
+    fish
+
+# Enable command completion in Zsh
+RUN echo "autoload -U compinit; compinit" > /etc/zsh/zshrc.d/completions.zsh \
+    && ln -s /usr/bin/fish /bin/fish
 
 # Configure www-data user as primary php-fpm user for better local dev experience
 RUN groupmod -g 1000 www-data && usermod -u 1000 www-data \

--- a/images/php-fpm/magento2/Dockerfile
+++ b/images/php-fpm/magento2/Dockerfile
@@ -9,11 +9,24 @@ RUN chmod +rx /usr/local/bin/n98-magerun2 \
     && ln -s /usr/local/bin/n98-magerun2 /usr/local/bin/n98-magerun \
     && ln -s /usr/local/bin/n98-magerun2 /usr/local/bin/magerun2 \
     && ln -s /usr/local/bin/n98-magerun2 /usr/local/bin/magerun \
-    && ln -s /usr/local/bin/n98-magerun2 /usr/local/bin/mr
+    && ln -s /usr/local/bin/n98-magerun2 /usr/local/bin/mr \
+    && ln -s /usr/local/bin/n98-magerun2 /usr/local/bin/n98-magerun2.phar
 
 # Magerun Auto-complete
 ADD https://raw.githubusercontent.com/netz98/n98-magerun2/master/res/autocompletion/bash/n98-magerun2.phar.bash /etc/bash_completion.d/n98-magerun2.phar
-RUN chmod +r /etc/bash_completion.d/n98-magerun2.phar
+ADD https://raw.githubusercontent.com/netz98/n98-magerun2/master/res/autocompletion/fish/n98-magerun2.phar.fish /etc/fish/completions/n98-magerun2.phar.fish
+ADD https://raw.githubusercontent.com/netz98/n98-magerun2/master/res/autocompletion/zsh/n98-magerun2.plugin.zsh /usr/share/zsh/site-functions/_n98-magerun2
+
+RUN sed -i 's/\(#compdef n98-magerun2.phar\)/\1 n98-magerun2=n98-magerun2.phar n98-magerun=n98-magerun2.phar magerun2=n98-magerun2.phar magerun=n98-magerun2.phar/' /usr/share/zsh/site-functions/_n98-magerun2 \
+    && sed -i 's/\(compdef _n98_magerun2 n98-magerun2.phar\)/\1 n98-magerun2=n98-magerun2.phar n98-magerun=n98-magerun2.phar magerun2=n98-magerun2.phar magerun=n98-magerun2.phar/' /usr/share/zsh/site-functions/_n98-magerun2 \
+    && sed -i 's/\(complete -f -c n98-magerun2.phar\)/\1 -c n98-magerun2 -c n98-magerun -c magerun2 -c magerun/' /etc/fish/completions/n98-magerun2.phar.fish \
+    && ln -s /etc/fish/completions/n98-magerun2.phar.fish /etc/fish/completions/n98-magerun2.fish \
+    && ln -s /etc/fish/completions/n98-magerun2.phar.fish /etc/fish/completions/n98-magerun.fish \
+    && ln -s /etc/fish/completions/n98-magerun2.phar.fish /etc/fish/completions/magerun2.fish \
+    && ln -s /etc/fish/completions/n98-magerun2.phar.fish /etc/fish/completions/magerun.fish \
+    && chmod +r /etc/fish/completions/n98-magerun2.phar.fish \
+    && chmod +r /etc/bash_completion.d/n98-magerun2.phar \
+    && chmod +r /usr/share/zsh/site-functions/_n98-magerun2
 
 # Mage2 TV Cache
 RUN mkdir /home/www-data/mage-cache-clean \


### PR DESCRIPTION
Adds Zsh and Fish shells (and composer and git completions for Zsh).

This would only work for php images (where you're most likely to use the shell).