### PR TITLE
#112: Enable mysqli extension

### DIFF
--- a/images/php-fpm/Dockerfile
+++ b/images/php-fpm/Dockerfile
@@ -24,6 +24,7 @@ RUN chmod +x /usr/local/bin/install-php-extensions && install-php-extensions \
     gd \
     intl \
     imagick \
+    mysqli \
     pcntl \
     pdo_mysql \
     redis \


### PR DESCRIPTION
Enables the MySQLi extesion in addition to the PDO extension. Only adds 1MB of size to the layer.

<table><thead><tr><th>Image</th><th>Command</th><th>Size</th></tr></thead>
<tbody>
<tr><td>Current Den Image</td><td><code>RUN /bin/sh -c chmod +x /usr/local/bin/install-php-extensions && install-php-extensions     amqp     bcmath     exif     gd     intl     imagick     pcntl     pdo_mysql     redis     soap     sockets     sodium     xsl     zip # buildkit </code></td><td>193MB</td></tr>
<tr><td>With MySQLi</td><td><code>RUN /bin/sh -c chmod +x /usr/local/bin/install-php-extensions && install-php-extensions     amqp     bcmath     exif     gd     intl     imagick     mysqli     pcntl     pdo_mysql     redis     soap     sockets     sodium     xsl     zip # buildkit </code></td><td>194MB</td></tr>
</tbody>
