### PR TITLE
Fix chrome-debug image name so docker can find image

### DIFF
--- a/environments/includes/selenium.base.yml
+++ b/environments/includes/selenium.base.yml
@@ -2,7 +2,7 @@ version: "3.5"
 services:
   selenium:
     hostname: ${WARDEN_ENV_NAME}_selenium
-    image: seleniarm/standalone-chrome${WARDEN_SELENIUM_DEBUG:-}:${WARDEN_SELENIUM_VERSION:-latest}
+    image: selenium/standalone-chrome${WARDEN_SELENIUM_DEBUG:-}:${WARDEN_SELENIUM_VERSION:-latest}
     extra_hosts:
       - ${TRAEFIK_DOMAIN}:${TRAEFIK_ADDRESS:-0.0.0.0}
       - ${TRAEFIK_SUBDOMAIN:-app}.${TRAEFIK_DOMAIN}:${TRAEFIK_ADDRESS:-0.0.0.0}

--- a/environments/includes/selenium.base.yml
+++ b/environments/includes/selenium.base.yml
@@ -2,7 +2,7 @@ version: "3.5"
 services:
   selenium:
     hostname: ${WARDEN_ENV_NAME}_selenium
-    image: selenium/standalone-chrome${WARDEN_SELENIUM_DEBUG:-}:${WARDEN_SELENIUM_VERSION:-latest}
+    image: seleniarm/standalone-chromium:${WARDEN_SELENIUM_VERSION:-latest}
     extra_hosts:
       - ${TRAEFIK_DOMAIN}:${TRAEFIK_ADDRESS:-0.0.0.0}
       - ${TRAEFIK_SUBDOMAIN:-app}.${TRAEFIK_DOMAIN}:${TRAEFIK_ADDRESS:-0.0.0.0}


### PR DESCRIPTION
When setting the WARDEN_SELENIUM_DEBUG variable to 1 in the .env file, den is unable to create the standalone selenium container due to a typo in the image name in selenium.base.yml. I see the seleniarm/standalone-chromium image, but there doesn't seem to be a debug image under this name.