### PR TITLE
Disables checking of client request body size in Nginx

### DIFF
--- a/images/nginx/etc/nginx/conf.d/default.conf
+++ b/images/nginx/etc/nginx/conf.d/default.conf
@@ -13,6 +13,8 @@ map "$http_X_BLACKFIRE_QUERY:$cookie_XDEBUG_SESSION$cookie_XDEBUG_PROFILE$cookie
     default ${NGINX_UPSTREAM_DEBUG_HOST}:${NGINX_UPSTREAM_DEBUG_PORT};
 }
 
+client_max_body_size 0;
+
 server {
     listen 80;
 


### PR DESCRIPTION
Currently, it's impossible to upload a 7M file in the admin panel because of the Nginx default limit.