### PR TITLE
Add support of MAGE_RUN_TYPE and MAGE_RUN_CODE param to nginx

### DIFF
--- a/images/nginx/Dockerfile
+++ b/images/nginx/Dockerfile
@@ -15,6 +15,7 @@ ENV XDEBUG_CONNECT_BACK_HOST      '""'
 
 COPY etc/nginx/fastcgi_params /etc/nginx/fastcgi_params.template
 COPY etc/nginx/conf.d/default.conf /etc/nginx/conf.d/default.conf.template
+COPY etc/nginx/conf.d/http.conf /etc/nginx/conf.d/http.conf
 COPY etc/nginx/available.d/*.conf /etc/nginx/available.d/
 
 CMD envsubst '${NGINX_UPSTREAM_HOST} ${NGINX_UPSTREAM_PORT} \

--- a/images/nginx/etc/nginx/available.d/magento2.conf
+++ b/images/nginx/etc/nginx/available.d/magento2.conf
@@ -153,6 +153,9 @@ location ~ \.php$ {
     fastcgi_busy_buffers_size 256k;
     fastcgi_read_timeout 3600s;
 
+    fastcgi_param MAGE_RUN_CODE $magento_multistore_key;
+    fastcgi_param MAGE_RUN_TYPE $magento_multistore_type;
+
     fastcgi_param  PHP_FLAG  "session.auto_start=off \n suhosin.session.cryptua=off";
     fastcgi_param  PHP_VALUE "max_execution_time=18000";
 

--- a/images/nginx/etc/nginx/conf.d/http.conf
+++ b/images/nginx/etc/nginx/conf.d/http.conf
@@ -1,0 +1,8 @@
+
+    map $http_host $magento_multistore_key {
+        default '';
+    }
+
+    map $http_host $magento_multistore_type {
+        default store;
+    }


### PR DESCRIPTION
The current approach for configuring multistore Magento requires adding some changes to a project specifically for a local environment that will be used on production as well. 
In order to avoid it we can configure it in files that are not going to be used on production.

The proposed approach requires adding two files into `.warden` folder:
- `.warden/nginx/http.conf`, here you can add your rules for your domains
```
    map $http_host$request_uri $magento_multistore_key {
        default '';
    }

    map $http_host$uri $magento_multistore_type {
        default store;
    }

```
- `.warden/warden-env.yml`, apply the config
```
version: "3.5"
services:
  nginx:
    volumes:
      - ./.warden/nginx/http.conf:/etc/nginx/conf.d/http.conf
```