### PR TITLE
Mount var folder for macOS

### DIFF
--- a/environments/includes/blackfire.darwin.yml
+++ b/environments/includes/blackfire.darwin.yml
@@ -3,4 +3,4 @@ services:
   php-blackfire:
     volumes:
       - /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock
-
+      - .${WARDEN_WEB_ROOT:-}/var:/var/www/html/var:cached

--- a/environments/magento2/magento2.darwin.yml
+++ b/environments/magento2/magento2.darwin.yml
@@ -2,10 +2,11 @@ version: "3.5"
 
 x-volumes: &volumes
   - .${WARDEN_WEB_ROOT:-}/pub/media:/var/www/html/pub/media:cached
+  - .${WARDEN_WEB_ROOT:-}/var:/var/www/html/var:cached
   - appdata:/var/www/html
 
 x-environment: &environment
-  - CHOWN_DIR_LIST=pub/media ${CHOWN_DIR_LIST:-}
+  - CHOWN_DIR_LIST=pub/media var ${CHOWN_DIR_LIST:-}
 
 services:
   nginx: { volumes: *volumes }

--- a/environments/magento2/magento2.mutagen.yml
+++ b/environments/magento2/magento2.mutagen.yml
@@ -7,7 +7,7 @@ sync:
     ignore:
       vcs: false
       paths:
-        # Root .git folder 
+        # Root .git folder
         - "/.git/"
 
         # System files
@@ -22,8 +22,7 @@ sync:
         - "/pub/media"
         - "/pub/static/**"
         - "!/pub/static/.htaccess"
-        - "/var/**"
-        - "!/var/.htaccess"
+        - "/var"
 
     permissions:
       defaultFileMode: "0644"


### PR DESCRIPTION
It is much more convenient to have direct access to the Magento `var` folder without the necessity to go inside the container.