### PR TITLE
Use a valid ElasticSearch fallback version

### DIFF
--- a/environments/includes/elasticsearch.base.yml
+++ b/environments/includes/elasticsearch.base.yml
@@ -2,7 +2,7 @@ version: "3.5"
 services:
   elasticsearch:
     hostname: "${WARDEN_ENV_NAME}-elasticsearch"
-    image: ${WARDEN_IMAGE_REPOSITORY}/den-elasticsearch:${ELASTICSEARCH_VERSION:-7.8}
+    image: ${WARDEN_IMAGE_REPOSITORY}/den-elasticsearch:${ELASTICSEARCH_VERSION:-7.9}
     labels:
       - traefik.enable=true
       - traefik.http.routers.${WARDEN_ENV_NAME}-elasticsearch.tls=true


### PR DESCRIPTION
For whatever reason [there's no 7.8 tag version of the ElasticSearch image](https://github.com/swiftotter/den/pkgs/container/den-elasticsearch/versions?filters%5Bversion_type%5D=tagged), which causes an `Error response from daemon: manifest unknown` error during `den env up` if no valid ELASTICSEARCH_VERSION is specified on the project .env:
![image](https://github.com/swiftotter/den/assets/4603111/20cd4c96-4275-4b6c-b55f-81c53e9ccda6)

This PR fixes that by using [7.9 tag](https://github.com/swiftotter/den/pkgs/container/den-elasticsearch/125227000?tag=7.9) as the fallback instead.

**PS.: _it may be interesting to simply make the 7.8 version image available again_**